### PR TITLE
Changed mentee PUT to use id from params

### DIFF
--- a/api/mentees/menteeRouter.js
+++ b/api/mentees/menteeRouter.js
@@ -59,7 +59,7 @@ router.post('/', async (req, res) => {
 router.put('/:id', (req, res) => {
   const mentee = req.body;
   if (mentee) {
-    const id = mentee.id || 0;
+    const id = req.params.id;
     Mentees.findById(id)
       .then(
         Mentees.update(id, mentee)


### PR DESCRIPTION
Fixed error in ID logic when editing mentees with PUT request. Using ID from params allows for editing on a field-by-field basis and fixes a bug where each request would edit user with ID 0 while potentially giving the end user the impression that the intended edit was successful.